### PR TITLE
Fix warnings, allow NULL usage information to be passed in

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -31,6 +31,7 @@ static void
 argparse_error(struct argparse *self, const struct argparse_option *opt,
                const char *reason, int flags)
 {
+    (void)self;
     if (flags & OPT_LONG) {
         fprintf(stderr, "error: option `--%s` %s\n", opt->long_name, reason);
     } else {
@@ -261,9 +262,14 @@ end:
 void
 argparse_usage(struct argparse *self)
 {
-    fprintf(stdout, "Usage: %s\n", *self->usages++);
-    while (*self->usages && **self->usages)
-        fprintf(stdout, "   or: %s\n", *self->usages++);
+    if (self->usages) {
+        fprintf(stdout, "Usage: %s\n", *self->usages++);
+        while (*self->usages && **self->usages)
+            fprintf(stdout, "   or: %s\n", *self->usages++);
+    }
+    else {
+        fprintf(stdout, "Usage:\n");
+    }
 
     // print description
     if (self->description)

--- a/argparse.h
+++ b/argparse.h
@@ -109,15 +109,15 @@ int argparse_help_cb(struct argparse *self,
                      const struct argparse_option *option);
 
 // built-in option macros
-#define OPT_END()        { ARGPARSE_OPT_END, 0, NULL, NULL, 0, NULL }
+#define OPT_END()        { ARGPARSE_OPT_END, 0, NULL, NULL, 0, NULL, 0, 0 }
 #define OPT_BOOLEAN(...) { ARGPARSE_OPT_BOOLEAN, __VA_ARGS__ }
 #define OPT_BIT(...)     { ARGPARSE_OPT_BIT, __VA_ARGS__ }
 #define OPT_INTEGER(...) { ARGPARSE_OPT_INTEGER, __VA_ARGS__ }
 #define OPT_STRING(...)  { ARGPARSE_OPT_STRING, __VA_ARGS__ }
-#define OPT_GROUP(h)     { ARGPARSE_OPT_GROUP, 0, NULL, NULL, h, NULL }
+#define OPT_GROUP(h)     { ARGPARSE_OPT_GROUP, 0, NULL, NULL, h, NULL, 0, 0 }
 #define OPT_HELP()       OPT_BOOLEAN('h', "help", NULL,                 \
                                      "show this help message and exit", \
-                                     argparse_help_cb)
+                                     argparse_help_cb, 0, 0)
 
 int argparse_init(struct argparse *self, struct argparse_option *options,
                   const char *const *usages, int flags);


### PR DESCRIPTION
Fix clang unused variable warnings, incomplete array structure initialization warnings. 
Allow usage to be optional.