### PR TITLE
docs: move name as name; add new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Name
+# argparse [![Build Status](https://travis-ci.org/cofyc/argparse.png)](https://travis-ci.org/cofyc/argparse)
 
 argparse - A command line arguments parsing library in C (compatible with C++).
-
-[![Build Status](https://travis-ci.org/cofyc/argparse.png)](https://travis-ci.org/cofyc/argparse)
 
 ## Description
 


### PR DESCRIPTION
Hi. This PR adds two things:

* the name should be the markdown heading. It's also customary to have the badge in the name
* the initial release is very old. Release should have tags

The second point makes it easier to vendor the lib in via...
```
git clone -b v1.0.1 --depth=1 https://github.com/cofyc/argparse include/argparse
```

and avoid cloning from (unpredictable) `master`.