### PR TITLE
Fix warnings in test

### DIFF
--- a/test_argparse.c
+++ b/test_argparse.c
@@ -25,15 +25,15 @@ main(int argc, const char **argv)
     struct argparse_option options[] = {
         OPT_HELP(),
         OPT_GROUP("Basic options"),
-        OPT_BOOLEAN('f', "force", &force, "force to do"),
-        OPT_BOOLEAN('t', "test", &test, "test only"),
-        OPT_STRING('p', "path", &path, "path to read"),
-        OPT_INTEGER('i', "int", &int_num, "selected integer"),
-        OPT_FLOAT('s', "float", &flt_num, "selected float"),
+        OPT_BOOLEAN('f', "force", &force, "force to do", NULL, 0, 0),
+        OPT_BOOLEAN('t', "test", &test, "test only", NULL, 0, 0),
+        OPT_STRING('p', "path", &path, "path to read", NULL, 0, 0),
+        OPT_INTEGER('i', "int", &int_num, "selected integer", NULL, 0, 0),
+        OPT_FLOAT('s', "float", &flt_num, "selected float", NULL, 0, 0),
         OPT_GROUP("Bits options"),
         OPT_BIT(0, "read", &perms, "read perm", NULL, PERM_READ, OPT_NONEG),
-        OPT_BIT(0, "write", &perms, "write perm", NULL, PERM_WRITE),
-        OPT_BIT(0, "exec", &perms, "exec perm", NULL, PERM_EXEC),
+        OPT_BIT(0, "write", &perms, "write perm", NULL, PERM_WRITE, 0),
+        OPT_BIT(0, "exec", &perms, "exec perm", NULL, PERM_EXEC, 0),
         OPT_END(),
     };
 


### PR DESCRIPTION
As described in issue #18, running make test with gcc produces many
warnings. This patch removes the warnings.