### PR TITLE
Refine Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,5 @@ test_argparse: $(OBJS)
 clean:
 	rm -rf test_argparse
 	rm -rf *.[ao]
+	rm -rf *.so
 	rm -rf *.dylib

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Defaults
 CFLAGS ?= -O3 -g -ggdb
 LDFLAGS ?=
+CROSS_COMPILE =
 
 BASIC_CFLAGS = -Wall -Wextra -fPIC
 BASIC_LDFLAGS = 
@@ -14,15 +15,15 @@ LIBNAME=libargparse
 DYLIBSUFFIX=so
 STLIBSUFFIX=a
 DYLIBNAME=$(LIBNAME).$(DYLIBSUFFIX)
-DYLIB_MAKE_CMD=$(CC) -shared -o $(DYLIBNAME) $(ALL_LDFLAGS)
+DYLIB_MAKE_CMD=$(CROSS_COMPILE)gcc -shared -o $(DYLIBNAME) $(ALL_LDFLAGS)
 STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
-STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
+STLIB_MAKE_CMD=$(CROSS_COMPILE)ar rcs $(STLIBNAME)
 
 # Platform-specific overrides
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 ifeq ($(uname_S),Darwin)
 DYLIBSUFFIX=dylib
-DYLIB_MAKE_CMD=$(CC) -shared -o $(DYLIBNAME) $(ALL_LDFLAGS)
+DYLIB_MAKE_CMD=$(CROSS_COMPILE)gcc -shared -o $(DYLIBNAME) $(ALL_LDFLAGS)
 endif
 
 all: $(DYLIBNAME) $(STLIBNAME)
@@ -31,7 +32,7 @@ OBJS += argparse.o
 OBJS += test_argparse.o
 
 $(OBJS): %.o: %.c argparse.h
-	$(CC) -o $*.o -c $(ALL_CFLAGS) $<
+	$(CROSS_COMPILE)gcc -o $*.o -c $(ALL_CFLAGS) $<
 
 $(DYLIBNAME): argparse.o
 	$(DYLIB_MAKE_CMD) $^
@@ -44,7 +45,7 @@ test: test_argparse
 	@./test.sh
 
 test_argparse: $(OBJS)
-	$(CC) $(ALL_CFLAGS) -o $@ $^ $(ALL_LDFLAGS)
+	$(CROSS_COMPILE)gcc $(ALL_CFLAGS) -o $@ $^ $(ALL_LDFLAGS)
 
 clean:
 	rm -rf test_argparse


### PR DESCRIPTION
- add support for cross compilation
- remove *.so file when `make clean`