### PR TITLE
Fixed portability of return code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options and non-option arguments can clearly be separated using the `--` option.
 ## Examples
 
 ```c
+#include <stdio.h>
 #include "argparse.h"
 
 static const char *const usage[] = {

--- a/argparse.c
+++ b/argparse.c
@@ -43,7 +43,7 @@ argparse_error(struct argparse *self, const struct argparse_option *opt,
     } else {
         fprintf(stderr, "error: option `-%c` %s\n", opt->short_name, reason);
     }
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 static int
@@ -274,7 +274,7 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
 unknown:
         fprintf(stderr, "error: unknown option `%s`\n", self->argv[0]);
         argparse_usage(self);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
 end:
@@ -380,5 +380,5 @@ argparse_help_cb(struct argparse *self, const struct argparse_option *option)
 {
     (void)option;
     argparse_usage(self);
-    exit(0);
+    exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
/assign @cofyc My operating system, [MorphOS](https://www.morphos-team.net), uses higher return codes.