### PR TITLE
fix test failures on darwin

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -93,9 +93,9 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
         } else {
             argparse_error(self, opt, "requires a value", flags);
         }
-        if (errno)
-            argparse_error(self, opt, strerror(errno), flags);
-        if (s[0] != '\0')
+        if (errno == ERANGE)
+            argparse_error(self, opt, "numerical result out of range", flags);
+        if (s[0] != '\0') // no digits or contains invalid characters
             argparse_error(self, opt, "expects an integer value", flags);
         break;
     case ARGPARSE_OPT_FLOAT:
@@ -109,9 +109,9 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
         } else {
             argparse_error(self, opt, "requires a value", flags);
         }
-        if (errno)
-            argparse_error(self, opt, strerror(errno), flags);
-        if (s[0] != '\0')
+        if (errno == ERANGE)
+            argparse_error(self, opt, "numerical result out of range", flags);
+        if (s[0] != '\0') // no digits or contains invalid characters
             argparse_error(self, opt, "expects a numerical value", flags);
         break;
     default:

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ is "$(./test_argparse -i2 2>&1)" 'int_num: 2'
 is "$(./test_argparse -ia 2>&1)" 'error: option `-i` expects an integer value'
 
 is "$(./test_argparse -i 0xFFFFFFFFFFFFFFFFF 2>&1)" \
-   'error: option `-i` Numerical result out of range'
+   'error: option `-i` numerical result out of range'
 
 is "$(./test_argparse -s 2.4 2>&1)" 'flt_num: 2.4'
 
@@ -28,7 +28,7 @@ is "$(./test_argparse -s2.4 2>&1)" 'flt_num: 2.4'
 is "$(./test_argparse -sa 2>&1)" 'error: option `-s` expects a numerical value'
 
 is "$(./test_argparse -s 1e999 2>&1)" \
-   'error: option `-s` Numerical result out of range'
+   'error: option `-s` numerical result out of range'
 
 is "$(./test_argparse -f -- do -f -h 2>&1)" 'force: 1
 argc: 3


### PR DESCRIPTION
- error messages returned by strerror() are not cross-platform compatibile, use custom errors instead

fixes #38 