### PR TITLE
Avoid MSVC 19 warnings

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -337,7 +337,7 @@ argparse_usage(struct argparse *self)
     options = self->options;
     for (; options->type != ARGPARSE_OPT_END; options++) {
         size_t pos = 0;
-        int pad    = 0;
+        size_t pad = 0;
         if (options->type == ARGPARSE_OPT_GROUP) {
             fputc('\n', stdout);
             fprintf(stdout, "%s", options->help);
@@ -367,7 +367,7 @@ argparse_usage(struct argparse *self)
             fputc('\n', stdout);
             pad = usage_opts_width;
         }
-        fprintf(stdout, "%*s%s\n", pad + 2, "", options->help);
+        fprintf(stdout, "%*s%s\n", (int)pad + 2, "", options->help);
     }
 
     // print epilog


### PR DESCRIPTION
conversion from 'size_t' to 'int', possible loss of data