### PR TITLE
Intentionally calling argparse on an empty argumentlist should print help

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -227,6 +227,11 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
 
     argparse_options_check(self->options);
 
+    if(!self->argc) {
+        argparse_usage(self);
+        exit(EXIT_FAILURE);
+    }
+
     for (; self->argc; self->argc--, self->argv++) {
         const char *arg = self->argv[0];
         if (arg[0] != '-' || !arg[1]) {


### PR DESCRIPTION
But separator argument -- is still a valid way to call it without prinitng help