### PR TITLE
Add ARGPARSE_IGNORE_UNKNOWN_ARGS flag

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -274,7 +274,9 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
 unknown:
         fprintf(stderr, "error: unknown option `%s`\n", self->argv[0]);
         argparse_usage(self);
-        exit(EXIT_FAILURE);
+        if (!self->flags & ARGPARSE_IGNORE_UNKNOWN_ARGS) {
+            exit(EXIT_FAILURE);
+        }
     }
 
 end:

--- a/argparse.h
+++ b/argparse.h
@@ -22,7 +22,8 @@ typedef int argparse_callback (struct argparse *self,
                                const struct argparse_option *option);
 
 enum argparse_flag {
-    ARGPARSE_STOP_AT_NON_OPTION = 1,
+    ARGPARSE_STOP_AT_NON_OPTION  = 1 << 0,
+    ARGPARSE_IGNORE_UNKNOWN_ARGS = 1 << 1,
 };
 
 enum argparse_option_type {


### PR DESCRIPTION
This PR adds an `argparse_flag` called `ARGPARSE_IGNORE_UNKNOWN_ARGS`, which allows args parsing to continue after encountering an arg that wasn't specified in the initial `argparse_option` list passed to `argparse_init`.

The current behavior is to exit when an "unknown" arg has been encountered in `argparse_parse`.