### PR TITLE
argparse_help_cb with no exit

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -378,17 +378,17 @@ argparse_usage(struct argparse *self)
 }
 
 int
-argparse_help_cb(struct argparse *self, const struct argparse_option *option)
-{
-    argparse_help_cb_no_exit(self, option);
-    exit(EXIT_SUCCESS);
-}
-
-int
 argparse_help_cb_no_exit(struct argparse *self,
                          const struct argparse_option *option)
 {
     (void)option;
     argparse_usage(self);
+}
+
+int
+argparse_help_cb(struct argparse *self, const struct argparse_option *option)
+{
+    argparse_help_cb_no_exit(self, option);
+    exit(EXIT_SUCCESS);
 }
 

--- a/argparse.c
+++ b/argparse.c
@@ -380,7 +380,15 @@ argparse_usage(struct argparse *self)
 int
 argparse_help_cb(struct argparse *self, const struct argparse_option *option)
 {
-    (void)option;
-    argparse_usage(self);
+    argparse_help_cb_no_exit(self, option);
     exit(EXIT_SUCCESS);
 }
+
+int
+argparse_help_cb_no_exit(struct argparse *self,
+                         const struct argparse_option *option)
+{
+    (void)option;
+    argparse_usage(self);
+}
+

--- a/argparse.h
+++ b/argparse.h
@@ -104,6 +104,8 @@ struct argparse {
 // built-in callbacks
 int argparse_help_cb(struct argparse *self,
                      const struct argparse_option *option);
+int argparse_help_cb_no_exit(struct argparse *self,
+                             const struct argparse_option *option);
 
 // built-in option macros
 #define OPT_END()        { ARGPARSE_OPT_END, 0, NULL, NULL, 0, NULL, 0, 0 }
@@ -123,6 +125,7 @@ void argparse_describe(struct argparse *self, const char *description,
                        const char *epilog);
 int argparse_parse(struct argparse *self, int argc, const char **argv);
 void argparse_usage(struct argparse *self);
+
 
 #ifdef __cplusplus
 }

--- a/argparse.h
+++ b/argparse.h
@@ -126,7 +126,6 @@ void argparse_describe(struct argparse *self, const char *description,
 int argparse_parse(struct argparse *self, int argc, const char **argv);
 void argparse_usage(struct argparse *self);
 
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This can be used to print more information that simply cannot be placed in the `epilogue` param of argparse_describe(), such as licensing info or subcommand info