### PR TITLE
chore: added clib.json

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,11 @@
+{
+  "name": "argparse",
+  "version": "1.1.0",
+  "repo": "cofyc/argparse",
+  "description": "Command-line arguments parsing library",
+  "license": "MIT",
+  "src": [
+    "argparse.c",
+    "argparse.h"
+  ]
+}


### PR DESCRIPTION
Added a JSON dictionary for the clib package manager to make installing argparse in new projects more convenient.