### PR TITLE
Fix inconsistent code style from PR #57

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -130,17 +130,17 @@ argparse_options_check(const struct argparse_option *options)
 {
     for (; options->type != ARGPARSE_OPT_END; options++) {
         switch (options->type) {
-            case ARGPARSE_OPT_END:
-            case ARGPARSE_OPT_BOOLEAN:
-            case ARGPARSE_OPT_BIT:
-            case ARGPARSE_OPT_INTEGER:
-            case ARGPARSE_OPT_FLOAT:
-            case ARGPARSE_OPT_STRING:
-            case ARGPARSE_OPT_GROUP:
-                continue;
-            default:
-                fprintf(stderr, "wrong option type: %d", options->type);
-                break;
+        case ARGPARSE_OPT_END:
+        case ARGPARSE_OPT_BOOLEAN:
+        case ARGPARSE_OPT_BIT:
+        case ARGPARSE_OPT_INTEGER:
+        case ARGPARSE_OPT_FLOAT:
+        case ARGPARSE_OPT_STRING:
+        case ARGPARSE_OPT_GROUP:
+            continue;
+        default:
+            fprintf(stderr, "wrong option type: %d", options->type);
+            break;
         }
     }
 }
@@ -383,7 +383,7 @@ argparse_help_cb_no_exit(struct argparse *self,
 {
     (void)option;
     argparse_usage(self);
-    return (EXIT_SUCCESS);
+    return 0;
 }
 
 int


### PR DESCRIPTION
## Summary

This PR addresses the code style inconsistencies introduced in PR #57, as reported in issue #74:

- **Fix K&R coding style**: Restore proper switch-case indentation where case labels align with the switch statement (not indented)
- **Correct return value**: Replace `EXIT_SUCCESS` with `0` in `argparse_help_cb_no_exit()` function, since `EXIT_SUCCESS` should only be used with `exit()` or returned by `main()`

## Changes Made

1. Fixed switch-case indentation in `argparse_options_check()` function to follow K&R style used throughout the codebase
2. Changed `return (EXIT_SUCCESS);` to `return 0;` in `argparse_help_cb_no_exit()` function for proper function return semantics

## Test Plan

- [x] All existing tests pass (`make test`)
- [x] Code compiles without warnings (`gcc -Wall -Wextra`)
- [x] Verified code style consistency with rest of codebase

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)